### PR TITLE
Add missing repository entry.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "directories": {
     "example": "example"
   },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:pelias/quattroshapes.git"
+  },
+
   "scripts": {
     "test": "node test/test | tap-spec"
   },


### PR DESCRIPTION
Without this I get
```
npm WARN EPACKAGEJSON pelias-quattroshapes@1.0.1 No repository field.
```