### PR TITLE
Add source: quattroshapes to all records

### DIFF
--- a/src/mapper.js
+++ b/src/mapper.js
@@ -59,6 +59,7 @@ function generateMapper( props, type ){
           type: type, // required to generate the unique id
         },
         name: {},
+        source: 'quattroshapes',
         alpha3: ( data.properties[ props.alpha3 ] || '' ).toUpperCase() || undefined,
         admin0: capitalize( data.properties[ props.admin0 ] ) || undefined,
         admin1: capitalize( data.properties[ props.admin1 ] ) || undefined,


### PR DESCRIPTION
Since the layers for Quattroshapes were already used for types, the
mapping already works correctly. The only change needed to bring
Quattroshapes up to speed is adding the source field. At least in
theory: again there are no tests.
